### PR TITLE
[FIX] 8.0 fix/context autonomo

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -1235,6 +1235,10 @@ class L10nBrSefip(models.Model):
         if folha.tipo_de_folha == 'decimo_terceiro':
             return result
 
+        # Em rescisoes a Rubrica que paga o 13 Salario
+        if folha.tipo_de_folha == 'rescisao':
+            result += self._valor_rubrica(folha.line_ids, 'PROP13')
+
         # Se o funcionario adiantou ferias no holerite do mes
         result += self._valor_rubrica(folha.line_ids, 'ADIANTAMENTO_13_FERIAS')
 

--- a/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
+++ b/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
@@ -23,7 +23,7 @@
                         </div>
                         <group>
                             <group>
-                                <field name="employee_id" required="True" domain="[('tipo', '=', 'autonomo')]" />
+                                <field name="employee_id" required="True" domain="[('tipo', '=', 'autonomo')]" context="{'default_tipo': 'autonomo'}"/>
                                 <field name="company_id" options="{'no_create': True, 'no_open': True}" required="1"/>
                                 <field name="job_id" required="True"
                                        options="{'no_create': True, 'no_open': True,

--- a/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
+++ b/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
@@ -24,7 +24,7 @@
                         </div>
                         <group>
                             <group>
-                                <field name="employee_id" required="True" domain="[('tipo', '=', 'autonomo')]" />
+                                <field name="employee_id" required="True" domain="[('tipo', '=', 'autonomo')]" context="{'default_tipo': 'autonomo'}"/>
                                 <field name="company_id" options="{'no_create': True, 'no_open': True}" required="1"/>
                                 <field name="job_id" required="True"
                                        options="{'no_create': True, 'no_open': True,

--- a/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
+++ b/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
@@ -11,6 +11,7 @@
         <record model="ir.ui.view" id="hr_contrato_autonomo_form_view">
             <field name="name">hr.contract.form (in l10n_br_hr_payroll)</field>
             <field name="model">hr.contract</field>
+            <field name="priority" eval="200"/>
             <field name="arch" type="xml">
                 <form string="Contract">
                     <sheet>


### PR DESCRIPTION
Passa como contexto o tipo de contrato 'autonomo' a partir do action do menu, novos contratos de autônomos criados não estavam tendo este campo populado corretamente.