### PR TITLE
[FIX] ID duplicado na visao do contrato

### DIFF
--- a/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
+++ b/l10n_br_hr_payroll/views/hr_contract_autonomo.xml
@@ -82,7 +82,6 @@
             <field name="name">Contrato Autônomo</field>
             <field name="res_model">hr.contract</field>
             <field name="view_type">form</field>
-            <field name="view_id" ref="hr_contrato_autonomo_tree_view"/>
             <field name="view_mode">tree,form</field>
             <field name="context">{'default_tipo': 'autonomo'}</field>
             <field name="domain">[('tipo','=', 'autonomo')]</field>
@@ -99,7 +98,7 @@
             <field eval="2" name="sequence"/>
             <field name="view_mode">form</field>
             <field name="act_window_id" ref="hr_contrato_autonomo_action"/>
-            <field name="view_id" ref="hr_contrato_autonomo_form_view"/>
+            <field name="view_id" ref="l10n_br_hr_payroll.hr_contrato_autonomo_form_view"/>
         </record>
 
     </data>

--- a/l10n_br_hr_payroll/views/hr_payslip_autonomo.xml
+++ b/l10n_br_hr_payroll/views/hr_payslip_autonomo.xml
@@ -144,20 +144,19 @@
                 parent="hr_payroll.menu_hr_root_payroll" sequence="130"
                 groups="base.group_hr_manager"/>
 
-        <record model="ir.actions.act_window.view" id="hr_contracto_autonomo_action_tree">
+        <record model="ir.actions.act_window.view" id="hr_payslip_autonomo_action_tree">
             <field eval="1" name="sequence"/>
             <field name="view_mode">tree</field>
             <field name="act_window_id" ref="hr_payslip_autonomo_action"/>
             <field name="view_id" ref="hr_payslip_autonomo_tree_view"/>
         </record>
 
-        <record model="ir.actions.act_window.view" id="hr_contracto_autonomo_action_form">
+        <record model="ir.actions.act_window.view" id="hr_payslip_autonomo_action_form">
             <field eval="2" name="sequence"/>
             <field name="view_mode">form</field>
             <field name="act_window_id" ref="hr_payslip_autonomo_action"/>
             <field name="view_id" ref="hr_payslip_autonomo_form_view"/>
         </record>
-
 
     </data>
 </openerp>


### PR DESCRIPTION
As visões do contrato estavam com ID duplicado, assim uma visão sobrescrevia a outra