### PR TITLE
[FIX] Remove relatorios antigos de holerite

### DIFF
--- a/l10n_br_hr_payroll_report/__openerp__.py
+++ b/l10n_br_hr_payroll_report/__openerp__.py
@@ -29,6 +29,7 @@
         'views/hr_field_rescission.xml',
         'views/hr_employee.xml',
         'views/hr_payslip.xml',
+        'views/hr_payroll_report.xml',
         'security/ir.model.access.csv',
     ],
     'installable': True,

--- a/l10n_br_hr_payroll_report/views/hr_payroll_report.xml
+++ b/l10n_br_hr_payroll_report/views/hr_payroll_report.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="hr_payroll.action_report_payslip" model="ir.actions.report.xml">
+            <field name="groups_id" eval="[(4, ref('base.group_no_one')), ]"/>
+        </record>
+
+         <record id="hr_payroll.payslip_details_report" model="ir.actions.report.xml">
+            <field name="groups_id" eval="[(4, ref('base.group_no_one')), ]"/>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Remove os botões "Imprimir > Holerite" e "Imprimir > Detalhes do Holerite" da visão dos funcionários.

Foi adicionado o grupo procedimentos técnicos para o relatório não ser exibido, dessa forma evitamos qualquer erro de atualização que possa vir a acontecer nos módulos de RH. 